### PR TITLE
change `main` property to `scripts`

### DIFF
--- a/component.json
+++ b/component.json
@@ -9,5 +9,6 @@
 	},
 	"development": {},
 	"license": "MIT",
+	"main": "ractive-transitions-fade.js",
 	"scripts": ["ractive-transitions-fade.js"]
 }


### PR DESCRIPTION
Component uses the `scripts` property to declare which files to include, so when I was installing the plugin via Component I wouldn't receive `ractive-transitions-fade.js`.  This fixes that.
