### PR TITLE
Fix bower `main` property

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
 	"name": "ractive-transitions-fade",
 	"version": "0.2.1",
 	"author": "Rich Harris",
-	"main": "ractive-transitions-fade.js",
+	"main": "dist/ractive-transitions-fade.js",
 	"ignore": [
 		".*",
 		"*.json",


### PR DESCRIPTION
bower.json should include dist/ directory prefix:

    "main": "dist/ractive-transitions-fade.js",

to point at the correct main script, similar to ractive-transitions-slide.

(I noticed due to webpack.ResolverPlugin.DirectoryDescriptionFilePlugin barfing on this transition, since it uses `main` to find the dependency.

